### PR TITLE
fixed files to compile on Ubuntu 16.04.4 VM

### DIFF
--- a/tsan/rtl/tsan_mman.cc
+++ b/tsan/rtl/tsan_mman.cc
@@ -13,6 +13,7 @@
 #include "sanitizer_common/sanitizer_allocator_checks.h"
 #include "sanitizer_common/sanitizer_allocator_interface.h"
 #include "sanitizer_common/sanitizer_common.h"
+#include "sanitizer_common/sanitizer_errno.h"
 #include "sanitizer_common/sanitizer_placement_new.h"
 #include "tsan_mman.h"
 #include "tsan_rtl.h"

--- a/tsan/rtl/tsan_rtl.cc
+++ b/tsan/rtl/tsan_rtl.cc
@@ -217,7 +217,7 @@ static void BackgroundThread(void *arg) {
                              memory_order_relaxed);
       if (last != 0 && last + flags()->flush_symbolizer_ms * kMs2Ns < now) {
         Lock l(&ctx->report_mtx);
-        SpinMutexLock l2(&CommonSanitizerReportMutex);
+        ScopedErrorReportLock l2;
         SymbolizeFlush();
         atomic_store(&ctx->last_symbolize_time_ns, 0, memory_order_relaxed);
       }
@@ -423,8 +423,7 @@ int Finalize(ThreadState *thr) {
 
   // Wait for pending reports.
   ctx->report_mtx.Lock();
-  CommonSanitizerReportMutex.Lock();
-  CommonSanitizerReportMutex.Unlock();
+  { ScopedErrorReportLock l; }
   ctx->report_mtx.Unlock();
 
 #if !SANITIZER_GO

--- a/tsan/rtl/tsan_rtl_amd64.S
+++ b/tsan/rtl/tsan_rtl_amd64.S
@@ -10,8 +10,8 @@
 #endif
 
 ASM_HIDDEN(__tsan_trace_switch)
-.globl ASM_TSAN_SYMBOL(__tsan_trace_switch_thunk)
-ASM_TSAN_SYMBOL(__tsan_trace_switch_thunk):
+.globl ASM_SYMBOL(__tsan_trace_switch_thunk)
+ASM_SYMBOL(__tsan_trace_switch_thunk):
   CFI_STARTPROC
   # Save scratch registers.
   push %rax
@@ -50,7 +50,7 @@ ASM_TSAN_SYMBOL(__tsan_trace_switch_thunk):
   shr $4, %rsp  # clear 4 lsb, align to 16
   shl $4, %rsp
 
-  call ASM_TSAN_SYMBOL(__tsan_trace_switch)
+  call ASM_SYMBOL(__tsan_trace_switch)
 
   # Unalign stack frame back.
   mov %rbx, %rsp  # restore the original rsp
@@ -90,8 +90,8 @@ ASM_TSAN_SYMBOL(__tsan_trace_switch_thunk):
   CFI_ENDPROC
 
 ASM_HIDDEN(__tsan_report_race)
-.globl ASM_TSAN_SYMBOL(__tsan_report_race_thunk)
-ASM_TSAN_SYMBOL(__tsan_report_race_thunk):
+.globl ASM_SYMBOL(__tsan_report_race_thunk)
+ASM_SYMBOL(__tsan_report_race_thunk):
   CFI_STARTPROC
   # Save scratch registers.
   push %rax
@@ -130,7 +130,7 @@ ASM_TSAN_SYMBOL(__tsan_report_race_thunk):
   shr $4, %rsp  # clear 4 lsb, align to 16
   shl $4, %rsp
 
-  call ASM_TSAN_SYMBOL(__tsan_report_race)
+  call ASM_SYMBOL(__tsan_report_race)
 
   # Unalign stack frame back.
   mov %rbx, %rsp  # restore the original rsp
@@ -173,9 +173,9 @@ ASM_HIDDEN(__tsan_setjmp)
 #if !defined(__APPLE__)
 .comm _ZN14__interception11real_setjmpE,8,8
 #endif
-.globl ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp)
-ASM_TYPE_FUNCTION(ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp))
-ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp):
+.globl ASM_SYMBOL_INTERCEPTOR(setjmp)
+ASM_TYPE_FUNCTION(ASM_SYMBOL_INTERCEPTOR(setjmp))
+ASM_SYMBOL_INTERCEPTOR(setjmp):
   CFI_STARTPROC
   // save env parameter
   push %rdi
@@ -197,7 +197,7 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp):
 # error "Unknown platform"
 #endif
   // call tsan interceptor
-  call ASM_TSAN_SYMBOL(__tsan_setjmp)
+  call ASM_SYMBOL(__tsan_setjmp)
   // restore env parameter
   pop %rdi
   CFI_ADJUST_CFA_OFFSET(-8)
@@ -208,15 +208,15 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp):
   movq _ZN14__interception11real_setjmpE@GOTPCREL(%rip), %rdx
   jmp *(%rdx)
 #else
-  jmp ASM_TSAN_SYMBOL(setjmp)
+  jmp ASM_SYMBOL(setjmp)
 #endif
   CFI_ENDPROC
-ASM_SIZE(ASM_TSAN_SYMBOL_INTERCEPTOR(setjmp))
+ASM_SIZE(ASM_SYMBOL_INTERCEPTOR(setjmp))
 
 .comm _ZN14__interception12real__setjmpE,8,8
-.globl ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp)
-ASM_TYPE_FUNCTION(ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp))
-ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp):
+.globl ASM_SYMBOL_INTERCEPTOR(_setjmp)
+ASM_TYPE_FUNCTION(ASM_SYMBOL_INTERCEPTOR(_setjmp))
+ASM_SYMBOL_INTERCEPTOR(_setjmp):
   CFI_STARTPROC
   // save env parameter
   push %rdi
@@ -238,7 +238,7 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp):
 # error "Unknown platform"
 #endif
   // call tsan interceptor
-  call ASM_TSAN_SYMBOL(__tsan_setjmp)
+  call ASM_SYMBOL(__tsan_setjmp)
   // restore env parameter
   pop %rdi
   CFI_ADJUST_CFA_OFFSET(-8)
@@ -249,15 +249,15 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp):
   movq _ZN14__interception12real__setjmpE@GOTPCREL(%rip), %rdx
   jmp *(%rdx)
 #else
-  jmp ASM_TSAN_SYMBOL(_setjmp)
+  jmp ASM_SYMBOL(_setjmp)
 #endif
   CFI_ENDPROC
-ASM_SIZE(ASM_TSAN_SYMBOL_INTERCEPTOR(_setjmp))
+ASM_SIZE(ASM_SYMBOL_INTERCEPTOR(_setjmp))
 
 .comm _ZN14__interception14real_sigsetjmpE,8,8
-.globl ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp)
-ASM_TYPE_FUNCTION(ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp))
-ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp):
+.globl ASM_SYMBOL_INTERCEPTOR(sigsetjmp)
+ASM_TYPE_FUNCTION(ASM_SYMBOL_INTERCEPTOR(sigsetjmp))
+ASM_SYMBOL_INTERCEPTOR(sigsetjmp):
   CFI_STARTPROC
   // save env parameter
   push %rdi
@@ -286,7 +286,7 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp):
 # error "Unknown platform"
 #endif
   // call tsan interceptor
-  call ASM_TSAN_SYMBOL(__tsan_setjmp)
+  call ASM_SYMBOL(__tsan_setjmp)
   // unalign stack frame
   add $8, %rsp
   CFI_ADJUST_CFA_OFFSET(-8)
@@ -304,16 +304,16 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp):
   movq _ZN14__interception14real_sigsetjmpE@GOTPCREL(%rip), %rdx
   jmp *(%rdx)
 #else
-  jmp ASM_TSAN_SYMBOL(sigsetjmp)
+  jmp ASM_SYMBOL(sigsetjmp)
 #endif
   CFI_ENDPROC
-ASM_SIZE(ASM_TSAN_SYMBOL_INTERCEPTOR(sigsetjmp))
+ASM_SIZE(ASM_SYMBOL_INTERCEPTOR(sigsetjmp))
 
 #if !defined(__APPLE__)
 .comm _ZN14__interception16real___sigsetjmpE,8,8
-.globl ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp)
-ASM_TYPE_FUNCTION(ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp))
-ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp):
+.globl ASM_SYMBOL_INTERCEPTOR(__sigsetjmp)
+ASM_TYPE_FUNCTION(ASM_SYMBOL_INTERCEPTOR(__sigsetjmp))
+ASM_SYMBOL_INTERCEPTOR(__sigsetjmp):
   CFI_STARTPROC
   // save env parameter
   push %rdi
@@ -337,7 +337,7 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp):
   rol $0x11, %rsi
 #endif
   // call tsan interceptor
-  call ASM_TSAN_SYMBOL(__tsan_setjmp)
+  call ASM_SYMBOL(__tsan_setjmp)
   // unalign stack frame
   add $8, %rsp
   CFI_ADJUST_CFA_OFFSET(-8)
@@ -354,7 +354,7 @@ ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp):
   movq _ZN14__interception16real___sigsetjmpE@GOTPCREL(%rip), %rdx
   jmp *(%rdx)
   CFI_ENDPROC
-ASM_SIZE(ASM_TSAN_SYMBOL_INTERCEPTOR(__sigsetjmp))
+ASM_SIZE(ASM_SYMBOL_INTERCEPTOR(__sigsetjmp))
 #endif  // !defined(__APPLE__)
 
 #if defined(__FreeBSD__) || defined(__linux__)

--- a/tsan/rtl/tsan_rtl_report.cc
+++ b/tsan/rtl/tsan_rtl_report.cc
@@ -150,11 +150,9 @@ ScopedReport::ScopedReport(ReportType typ, uptr tag) {
   rep_->typ = typ;
   rep_->tag = tag;
   ctx->report_mtx.Lock();
-  CommonSanitizerReportMutex.Lock();
 }
 
 ScopedReport::~ScopedReport() {
-  CommonSanitizerReportMutex.Unlock();
   ctx->report_mtx.Unlock();
   DestroyAndFree(rep_);
 }


### PR DESCRIPTION
Edited some files to get UFO to compile with LLVM on a Ubuntu 16.04.4 virtual machine

Specific Edits:
- tsan/rtl/tsan_mman.cc
       added line 16
- tsan/rtl/tsan_rtl.cc
       modified lines (previously known as) 220 and 426-427
- tsan/rtl/tsan_rtl_report.cc
       deleted lines (previously known as) 153 and 157
- tsan/rtl/tsan_rtl_amd64.cc
       changed all instances of "ASM_TSAN_" to "ASM_"