### PR TITLE
Update EventLoader.java

### DIFF
--- a/ufo-predict/src/main/java/aser/ufo/trace/EventLoader.java
+++ b/ufo-predict/src/main/java/aser/ufo/trace/EventLoader.java
@@ -44,9 +44,6 @@ public class EventLoader {
     windowSize = wsz;
 
     final File dir = new File(folderName);
-    if (!dir.isDirectory()) {
-      throw new RuntimeException("Could not find folder " + folderName);
-    }
     File[] traces = dir.listFiles(new FileFilter() {
       public boolean accept(File f) {
         if (!f.canRead()) {
@@ -56,7 +53,9 @@ public class EventLoader {
       }
     });
     if (traces == null)
-      throw new IllegalArgumentException("No trace file found at " + folderName);
+    	throw new RuntimeException("Could not find folder " + folderName);
+    if (traces.length == 0)
+    	throw new IllegalArgumentException("No trace file found at " + folderName);
 //    int flimt = 2;
     
     


### PR DESCRIPTION
**Fixed the error reporting in init() for reading in the traces**

File.listFiles returns a blank/empty array if there are no elements in a directory, not a null File array. This means that both the "dir.isDirectory" and "traces == null" checks for no folder

To account for this I used the null check (no folder) and a blank check (no files).